### PR TITLE
feat(backup): automatic daily OPFS snapshot and silent Drive upload

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -160,6 +160,36 @@
         "functions": ["TransactionsPage"],
         "maxCrap": 45,
         "reason": "Page composition wiring search/pagination/delete hooks plus the empty-state and infinite-scroll-sentinel ternaries; coverage-blind CRAP, not accidental complexity."
+      },
+      {
+        "files": ["src/components/more/backup/AutoBackupStatus.tsx"],
+        "functions": ["AutoBackupStatus"],
+        "maxCrap": 120,
+        "reason": "Quiet status row rendering: safety-copy line, Drive line, anomaly escape hatch, actionable-passphrase row, and the restore-history dialog are each an independent presence check; coverage-blind CRAP on a presentational component, not accidental complexity."
+      },
+      {
+        "files": ["src/lib/snapshotStore.ts"],
+        "functions": ["commitSnapshot"],
+        "maxCrap": 120,
+        "reason": "Write, reread-and-verify, delete-on-failure, build manifest, commit last, prune orphans -- a single-transaction commit protocol where the correctness argument depends on this exact order in one function."
+      },
+      {
+        "files": ["src/lib/autoBackup.ts"],
+        "functions": ["runTier1", "runAutoBackupBody", "runTier2", "degradeForQuota"],
+        "maxCrap": 100,
+        "reason": "Daily-gate/skip-unchanged/anomaly-guard/quota-degrade branching is the issue's specified auto-backup state machine; each branch is a distinct real-world outcome (unchanged, collapsed, degrade tier 1/2/3, offline, no-passphrase, session-expired), not accidental complexity."
+      },
+      {
+        "files": ["src/hooks/useAppStartup.ts"],
+        "functions": ["<arrow>"],
+        "maxCrap": 100,
+        "reason": "Startup sequencing: persisted-storage warning, data-loss detection, and the empty-list-with-snapshot restore offer all gate on the same boot state; matches the useExpenseFormController.ts <arrow> precedent above."
+      },
+      {
+        "files": ["src/components/DataLossDialog.tsx"],
+        "functions": ["DataLossDialog"],
+        "maxCrap": 35,
+        "reason": "lastSeenExpenseCount-present-vs-null and snapshot-present-vs-absent JSX branches; coverage-blind CRAP on an alert dialog, matches the DeleteCategoryDialog precedent above."
       }
     ]
   },

--- a/docs/features/drive-backup.md
+++ b/docs/features/drive-backup.md
@@ -1,10 +1,12 @@
 # 🔄 Google Drive Backup & Enhanced Export System
 
-**Status:** Spec Confirmed — Ready for Implementation  
-**Version:** 0.2.0  
-**Date:** 2026-03-02  
+**Status:** Implemented — Phases 1-4 shipped (client-side encryption, silent OAuth refresh,
+automatic daily Tier 1/Tier 2 backup, and one-tap restore); Phase 5 (browse/import from Drive UI)
+remains future scope.  
+**Version:** 0.3.0  
+**Date:** 2026-08-28  
 **Target Release:** Feature Set 3  
-**Active Phases:** Phase 1 (Backup Reminders) + Phase 2 (Simplified Export)
+**Active Phases:** All of Phase 1-4
 
 ---
 
@@ -86,15 +88,17 @@ Enhance the existing export/import system with:
 - Account management: View status, change folder, unlink account
 - Graceful fallback to device export if Drive or auth fails
 
-**🔒 Future Scope: Client-Side Encryption**
+**🔒 Client-Side Encryption (Shipped)**
 
-- Encrypt backup JSON locally using Web Crypto API before upload (Explore other AES etc ways.)
-- Zero knowledge
-- Only the user can decrypt (key derived from a user-defined passphrase or device key)
-- Even if Google Drive is compromised/leaked, data is unreadable
-- Decrypt locally on import (no server involved)
-- Requires user-selected folder (not `appDataFolder`) so user can manage encrypted files
-- Incremental: encryption layer added on top of existing Drive upload
+- Every file that leaves the origin sandbox (Drive uploads, manual exports) is encrypted with
+  AES-GCM-256, key derived via PBKDF2-SHA256 (600k iterations) from a user-defined passphrase —
+  see `src/lib/backup.ts`.
+- Zero knowledge: only the user's passphrase can decrypt; Google never sees plaintext.
+- Decrypted locally on import — no server involved.
+- The automatic local OPFS snapshot (Tier 1 of the auto-backup feature, see
+  `src/lib/snapshotStore.ts` / `src/lib/autoBackup.ts`) is deliberately **plaintext** — it never
+  leaves the origin sandbox, the same boundary that already protects the unencrypted IndexedDB it
+  copies from.
 
 ---
 
@@ -481,17 +485,16 @@ function shouldShowReminderBanner(settings: BackupSettings): boolean {
 - [ ] Test token auto-refresh (wait ~1hr or force expiry)
 - [ ] Test offline behavior (graceful failure message)
 
-### **Phase 4: Client-Side Encryption (Future Scope)**
+### **Phase 4: Client-Side Encryption (Shipped)**
 
-**Effort:** 6-8 hours  
-**Goal:** Zero-knowledge backups — even Google cannot read exported files
-
-- Encrypt JSON locally using Web Crypto API (AES-GCM) before Drive upload
-- Key derived from user passphrase (PBKDF2)
-- Encrypted file uploaded to user-selected Drive folder
-- On import: detect encrypted file, prompt passphrase, decrypt locally
-- No passphrase stored anywhere — user is responsible
-- Works for device export too (optional encrypted local backup)
+- Encrypted locally using Web Crypto API (AES-GCM-256) before Drive upload
+- Key derived from user passphrase (PBKDF2-SHA256, 600k iterations)
+- Encrypted file uploaded to the `ExTrack Backups` Drive folder
+- On import: detect encrypted file, decrypt with stored or manually-entered passphrase
+- Passphrase stored in the same IndexedDB database as the data it protects — see
+  `src/lib/backup.ts` for the deliberate reasoning (the automatic OPFS snapshot stays plaintext
+  for the same reason: encrypting it would add no attacker resistance, only a failure mode)
+- Also protects the automatic daily device export (see `src/lib/autoBackup.ts`)
 
 ### **Phase 5: Import from Drive** (Future Scope)
 
@@ -541,7 +544,7 @@ Before implementation, confirm:
 | 3   | Drive folder              | **User-selected folder** via Google Picker (not `appDataFolder`)                                                                   |
 | 4   | Token storage             | IndexedDB plaintext for now                                                                                                        |
 | 5   | Token lifetime            | Access token: ~1hr; Refresh token: long-lived (until revoked)                                                                      |
-| 6   | File encryption           | Future scope (Phase 4) — AES-GCM via Web Crypto API, user passphrase                                                               |
+| 6   | File encryption           | Shipped — AES-GCM-256 via Web Crypto API, user passphrase (PBKDF2-SHA256, 600k iterations)                                          |
 | 7   | Multiple backups          | User-managed in their chosen folder; no auto-cleanup by app                                                                        |
 | 8   | CSV for Drive             | Not supported — Drive is JSON only; CSV available for device export                                                                |
 | 9   | Import source             | Device (JSON only), Drive import is future scope (Phase 5)                                                                         |
@@ -568,11 +571,13 @@ Before implementation, confirm:
 1. ✅ ~~Review plan and confirm approach~~
 2. ✅ ~~Answer open questions~~
 3. ✅ ~~Prioritize phases~~
-4. **Implement Phase 1** — Backup reminder system + BackupSettings UI
-5. **Implement Phase 2** — Simplified export dialog
-6. Test Phase 1 + 2 together end-to-end
-7. Plan Phase 3 (Drive integration) after Phase 1+2 are stable
+4. ✅ ~~Implement Phase 1~~ — Backup reminder system + BackupSettings UI
+5. ✅ ~~Implement Phase 2~~ — Simplified export dialog
+6. ✅ ~~Implement Phase 3~~ — Google Drive integration
+7. ✅ ~~Implement Phase 4~~ — Client-side encryption + automatic daily Tier 1/Tier 2 backup
+8. Phase 5 (browse/import from Drive UI) remains future scope
 
 ---
 
-**Spec confirmed. Ready to implement Phase 1 + Phase 2.**
+**Phases 1-4 shipped.** See `src/lib/autoBackup.ts`, `src/lib/snapshotStore.ts`, and
+`tests/e2e/auto-backup.spec.ts` for the automatic-backup layer.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { BrowserRouter, Routes, Route, useNavigate } from "react-router";
+import { toast } from "sonner";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { ReloadPrompt } from "@/components/ReloadPrompt";
@@ -10,6 +11,8 @@ import { lazy } from "react";
 import { initializeDatabase } from "@/db/expenseTrackerDb";
 import { userPreferences } from "@/db/userPreferences";
 import { useAppStartup } from "@/hooks/useAppStartup";
+import { markAutoBackup } from "@/lib/backup";
+import { restoreSnapshot } from "@/lib/autoBackup";
 
 import HomePage from "./pages/HomePage";
 
@@ -31,7 +34,8 @@ const BulkAddPage = lazy(() => import("@/pages/BulkAddPage"));
 
 function AppContent() {
   const navigate = useNavigate();
-  const { lossCount, setLossCount, lossDialogOpen, setLossDialogOpen } = useAppStartup();
+  const { lossCount, setLossCount, lossDialogOpen, setLossDialogOpen, restoreOffer, setRestoreOffer } =
+    useAppStartup();
 
   return (
     <AppLayout>
@@ -50,10 +54,11 @@ function AppContent() {
         <Route path="/settings/about" element={<AboutPage />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
-      {lossCount !== null && (
+      {(lossCount !== null || restoreOffer !== null) && (
         <DataLossDialog
           open={lossDialogOpen}
           lastSeenExpenseCount={lossCount}
+          snapshot={restoreOffer}
           onStartFresh={() => {
             const freshNow = new Date().toISOString();
             userPreferences.setInstallMarker({
@@ -61,14 +66,36 @@ function AppContent() {
               lastSeenAt: freshNow,
               lastSeenExpenseCount: 0,
             });
+            if (restoreOffer) markAutoBackup({ restoreOfferDeclinedFor: restoreOffer.name });
             setLossDialogOpen(false);
             setLossCount(null);
+            setRestoreOffer(null);
             void initializeDatabase();
           }}
           onRestore={() => {
             setLossDialogOpen(false);
             navigate("/settings/data");
           }}
+          onRestoreSnapshot={
+            restoreOffer
+              ? () => {
+                  const offer = restoreOffer;
+                  void restoreSnapshot(offer.name)
+                    .then(({ expenseCount }) => {
+                      setLossDialogOpen(false);
+                      setLossCount(null);
+                      setRestoreOffer(null);
+                      toast.success(
+                        `Restored ${expenseCount} expenses. Currency and theme settings are not part of a safety copy.`,
+                      );
+                      navigate("/transactions");
+                    })
+                    .catch((err: unknown) => {
+                      toast.error(err instanceof Error ? err.message : "Restore failed");
+                    });
+                }
+              : undefined
+          }
         />
       )}
       <BackupReminderPrompt />

--- a/src/components/BackupReminderPrompt.tsx
+++ b/src/components/BackupReminderPrompt.tsx
@@ -5,6 +5,7 @@ import {
   getDaysSinceLastBackup,
   markBackupReminderBannerShown,
   shouldShowBackupReminderBanner,
+  toDateKey,
 } from "@/lib/backup";
 import { type BackupReminderSchedule } from "@/db/userPreferences";
 import { BackupReminderBanner } from "@/components/BackupReminderBanner";
@@ -37,8 +38,24 @@ function getLastBackupText(daysSinceLastBackup: number | null): string {
   return `Last backup: ${daysSinceLastBackup} day${daysSinceLastBackup === 1 ? "" : "s"} ago.`;
 }
 
+const AUTO_BACKUP_FAILURE_THRESHOLD = 3;
+
 function getInitialPromptState(): PromptState {
   const preferences = getBackupReminderPreferences();
+
+  // Sustained automatic-backup failure escalates to this same banner surface, gated by the
+  // existing once-a-day bannerLastShownDate check — one banner, not a daily nag on top of it.
+  if (
+    preferences.autoBackupFailures >= AUTO_BACKUP_FAILURE_THRESHOLD &&
+    preferences.bannerLastShownDate !== toDateKey(new Date())
+  ) {
+    return {
+      visible: true,
+      schedule: preferences.reminderSchedule,
+      message: "Automatic backup has failed for 3 days in a row. Check your connection or Drive link.",
+    };
+  }
+
   const visible = shouldShowBackupReminderBanner(preferences);
 
   if (!visible) {

--- a/src/components/DataLossDialog.tsx
+++ b/src/components/DataLossDialog.tsx
@@ -1,3 +1,4 @@
+import { format } from "date-fns";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -8,18 +9,27 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 
+interface SnapshotOffer {
+  writtenAt: string;
+  expenseCount: number;
+}
+
 interface DataLossDialogProps {
   open: boolean;
-  lastSeenExpenseCount: number;
+  lastSeenExpenseCount: number | null;
+  snapshot?: SnapshotOffer | null;
   onStartFresh: () => void;
   onRestore: () => void;
+  onRestoreSnapshot?: () => void;
 }
 
 export function DataLossDialog({
   open,
   lastSeenExpenseCount,
+  snapshot = null,
   onStartFresh,
   onRestore,
+  onRestoreSnapshot,
 }: DataLossDialogProps) {
   return (
     <AlertDialog open={open}>
@@ -29,25 +39,47 @@ export function DataLossDialog({
           <AlertDialogDescription asChild className="text-left">
             <div className="space-y-3 pt-2">
               <div className="text-sm text-foreground">
-                This device previously held <span className="font-medium">{lastSeenExpenseCount}</span>{" "}
-                expense{lastSeenExpenseCount === 1 ? "" : "s"}, but the browser&apos;s storage for
-                this app is now empty.
+                {lastSeenExpenseCount !== null ? (
+                  <>
+                    This device previously held{" "}
+                    <span className="font-medium">{lastSeenExpenseCount}</span> expense
+                    {lastSeenExpenseCount === 1 ? "" : "s"}, but the browser&apos;s storage for this
+                    app is now empty.
+                  </>
+                ) : (
+                  "Your expense list is empty."
+                )}
               </div>
-              <div className="text-xs text-muted-foreground">
-                This usually means the browser cleared its storage. If you have a backup file or a
-                Google Drive backup, restore it now — starting fresh discards the chance to recover
-                this device's copy.
-              </div>
+              {snapshot ? (
+                <div className="text-xs text-muted-foreground">
+                  We found a local safety copy from{" "}
+                  {format(new Date(snapshot.writtenAt), "MMM d, h:mm a")} with{" "}
+                  <span className="font-medium">{snapshot.expenseCount}</span> expenses. Restore it?
+                </div>
+              ) : (
+                <div className="text-xs text-muted-foreground">
+                  This usually means the browser cleared its storage. If you have a backup file or a
+                  Google Drive backup, restore it now — starting fresh discards the chance to recover
+                  this device's copy.
+                </div>
+              )}
             </div>
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogAction onClick={onStartFresh} className="bg-secondary text-secondary-foreground hover:bg-secondary/80">
+          <AlertDialogAction
+            onClick={onStartFresh}
+            className="bg-secondary text-secondary-foreground hover:bg-secondary/80"
+          >
             Start fresh
           </AlertDialogAction>
-          <AlertDialogAction onClick={onRestore}>
-            Restore from backup
-          </AlertDialogAction>
+          {snapshot ? (
+            <AlertDialogAction onClick={onRestoreSnapshot}>
+              Restore {snapshot.expenseCount} expenses
+            </AlertDialogAction>
+          ) : (
+            <AlertDialogAction onClick={onRestore}>Restore from backup</AlertDialogAction>
+          )}
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/src/components/more/BackupCard.tsx
+++ b/src/components/more/BackupCard.tsx
@@ -3,6 +3,7 @@ import { useDriveConnection } from "@/hooks/useDriveConnection";
 import { useBackupReminderSchedule } from "@/hooks/useBackupReminderSchedule";
 import { ReminderScheduleSelect } from "@/components/more/backup/ReminderScheduleSelect";
 import { DriveConnectionRow } from "@/components/more/backup/DriveConnectionRow";
+import { AutoBackupStatus } from "@/components/more/backup/AutoBackupStatus";
 
 interface BackupCardProps {
   openOnMount?: boolean;
@@ -16,7 +17,8 @@ export function BackupCard({ openOnMount = false, onBackupSuccess }: BackupCardP
   return (
     <div className="space-y-1">
       <h2 className="text-sm font-semibold">Backup</h2>
-      <p className="text-xs text-muted-foreground pb-3">{lastBackupText}</p>
+      <p className="text-xs text-muted-foreground pb-1">{lastBackupText}</p>
+      <AutoBackupStatus />
 
       {/* Reminder frequency row */}
       <div className="flex items-center justify-between py-2">

--- a/src/components/more/backup/AutoBackupStatus.tsx
+++ b/src/components/more/backup/AutoBackupStatus.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useState } from "react";
+import { format } from "date-fns";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { getBackupReminderPreferences, getStoredPassphrase } from "@/lib/backup";
+import { AUTO_BACKUP_UPDATED_EVENT, restoreSnapshot, runAutoBackup } from "@/lib/autoBackup";
+import { opfsAvailable, readManifest, type SnapshotManifest } from "@/lib/snapshotStore";
+import { getDriveCredentials } from "@/db/driveCredentials";
+
+/** Quiet status row for `BackupCard`: last automatic snapshot/Drive time, an anomaly escape
+ *  hatch, and the "restore from a safety copy" list. Renders nothing when OPFS is unavailable —
+ *  Tier 1 is inert there, and this row exists only to report on it. */
+export function AutoBackupStatus() {
+  const [manifest, setManifest] = useState<SnapshotManifest | null>(null);
+  const [prefs, setPrefs] = useState(() => getBackupReminderPreferences());
+  const [driveActionable, setDriveActionable] = useState(false);
+  const [isRunning, setIsRunning] = useState(false);
+
+  async function refresh() {
+    const [nextManifest, creds, passphrase] = await Promise.all([
+      readManifest(),
+      getDriveCredentials(),
+      getStoredPassphrase(),
+    ]);
+    setManifest(nextManifest);
+    setPrefs(getBackupReminderPreferences());
+    setDriveActionable(creds !== null && !passphrase);
+  }
+
+  useEffect(() => {
+    void refresh();
+    const handleUpdate = () => void refresh();
+    window.addEventListener(AUTO_BACKUP_UPDATED_EVENT, handleUpdate);
+    return () => window.removeEventListener(AUTO_BACKUP_UPDATED_EVENT, handleUpdate);
+  }, []);
+
+  if (!opfsAvailable()) return null;
+
+  const latest = manifest?.history[0] ?? null;
+
+  async function handleSnapshotNow() {
+    setIsRunning(true);
+    try {
+      await runAutoBackup({ force: true });
+      await refresh();
+    } finally {
+      setIsRunning(false);
+    }
+  }
+
+  async function handleRestore(name: string) {
+    try {
+      const { expenseCount } = await restoreSnapshot(name);
+      toast.success(
+        `Restored ${expenseCount} expenses. Currency and theme settings are not part of a safety copy.`,
+      );
+      await refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Restore failed");
+    }
+  }
+
+  return (
+    <div className="space-y-1 py-2 text-xs text-muted-foreground">
+      {latest && (
+        <div>
+          Safety copy: {format(new Date(latest.writtenAt), "MMM d, h:mm a")} · {latest.expenseCount}{" "}
+          expense{latest.expenseCount === 1 ? "" : "s"}
+        </div>
+      )}
+      {prefs.lastAutoDriveAt && <div>Drive: {format(new Date(prefs.lastAutoDriveAt), "MMM d")}</div>}
+      {prefs.autoBackupAnomaly && (
+        <div className="flex items-center justify-between gap-2 text-amber-600">
+          <span>{prefs.autoBackupAnomaly}</span>
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-6 shrink-0 px-2 text-xs"
+            onClick={handleSnapshotNow}
+            disabled={isRunning}
+          >
+            Snapshot now
+          </Button>
+        </div>
+      )}
+      {driveActionable && <div>Drive is linked but no passphrase is set</div>}
+      {manifest && manifest.history.length > 0 && (
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button variant="ghost" size="sm" className="h-6 px-0 text-xs underline">
+              Restore from safety copy
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Restore from safety copy</AlertDialogTitle>
+              <AlertDialogDescription asChild className="text-left">
+                <div className="space-y-2 pt-2 text-sm">
+                  {manifest.history.map((entry) => (
+                    <div key={entry.name} className="flex items-center justify-between gap-2">
+                      <span>
+                        {format(new Date(entry.writtenAt), "MMM d, h:mm a")} · {entry.expenseCount}{" "}
+                        expenses
+                        {entry.partial ? " (partial)" : ""}
+                      </span>
+                      <AlertDialogAction onClick={() => handleRestore(entry.name)}>
+                        Restore
+                      </AlertDialogAction>
+                    </div>
+                  ))}
+                </div>
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Close</AlertDialogCancel>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+    </div>
+  );
+}

--- a/src/db/userPreferences.ts
+++ b/src/db/userPreferences.ts
@@ -14,6 +14,16 @@ export interface BackupReminderPreferences {
   lastBackupDate: string | null;
   lastBackupMode: BackupMode | null;
   bannerLastShownDate: string | null;
+  /** Tier 1 (OPFS) — date key ("yyyy-MM-dd") of the last successful automatic snapshot. */
+  lastAutoSnapshotAt: string | null;
+  /** Tier 2 (Drive) — date key of the last successful silent upload. */
+  lastAutoDriveAt: string | null;
+  /** Consecutive automatic-backup failures (either tier), reset to 0 on any success. */
+  autoBackupFailures: number;
+  /** Human-readable reason the last automatic snapshot refused to overwrite, or null. */
+  autoBackupAnomaly: string | null;
+  /** Snapshot name the user already declined restoring, so it isn't re-offered. */
+  restoreOfferDeclinedFor: string | null;
 }
 
 export interface InstallMarker {
@@ -37,6 +47,11 @@ const DEFAULT_BACKUP_REMINDER_PREFERENCES: BackupReminderPreferences = {
   lastBackupDate: null,
   lastBackupMode: null,
   bannerLastShownDate: null,
+  lastAutoSnapshotAt: null,
+  lastAutoDriveAt: null,
+  autoBackupFailures: 0,
+  autoBackupAnomaly: null,
+  restoreOfferDeclinedFor: null,
 };
 
 const INSTALL_MARKER_VALIDATORS: [keyof InstallMarker, (parsed: Partial<InstallMarker>) => boolean][] = [
@@ -119,6 +134,16 @@ class UserPreferences {
         lastBackupDate: pickString(parsed.lastBackupDate, null),
         lastBackupMode,
         bannerLastShownDate: pickString(parsed.bannerLastShownDate, null),
+        lastAutoSnapshotAt: pickString(parsed.lastAutoSnapshotAt, null),
+        lastAutoDriveAt: pickString(parsed.lastAutoDriveAt, null),
+        autoBackupFailures:
+          typeof parsed.autoBackupFailures === "number" &&
+          Number.isFinite(parsed.autoBackupFailures) &&
+          parsed.autoBackupFailures >= 0
+            ? parsed.autoBackupFailures
+            : DEFAULT_BACKUP_REMINDER_PREFERENCES.autoBackupFailures,
+        autoBackupAnomaly: pickString(parsed.autoBackupAnomaly, null),
+        restoreOfferDeclinedFor: pickString(parsed.restoreOfferDeclinedFor, null),
       };
     } catch {
       return DEFAULT_BACKUP_REMINDER_PREFERENCES;

--- a/src/hooks/useAppStartup.ts
+++ b/src/hooks/useAppStartup.ts
@@ -1,17 +1,28 @@
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { initializeDatabase, requestPersistentStorage } from "@/db/expenseTrackerDb";
+import { db, initializeDatabase, requestPersistentStorage } from "@/db/expenseTrackerDb";
 import { capture } from "@/lib/telemetry";
+import { getBackupReminderPreferences } from "@/lib/backup";
+import { runAutoBackup } from "@/lib/autoBackup";
+import { readManifest } from "@/lib/snapshotStore";
+
+export interface RestoreOffer {
+  name: string;
+  writtenAt: string;
+  expenseCount: number;
+}
 
 export function useAppStartup() {
   const [lossCount, setLossCount] = useState<number | null>(null);
   const [lossDialogOpen, setLossDialogOpen] = useState(false);
+  const [restoreOffer, setRestoreOffer] = useState<RestoreOffer | null>(null);
 
   useEffect(() => {
     void (async () => {
       const persisted = await requestPersistentStorage();
       const state = await initializeDatabase();
       capture("app_opened", { persisted, startup: state.status });
+      void runAutoBackup();
 
       if (!persisted) {
         // Hard navigation (not `navigate()`) — this fires before the router's
@@ -22,7 +33,8 @@ export function useAppStartup() {
         });
       }
 
-      if (state.status === "data-loss") {
+      const isWipe = state.status === "data-loss";
+      if (isWipe && state.status === "data-loss") {
         setLossCount(state.lastSeenExpenseCount);
         setLossDialogOpen(true);
         capture("data_loss_detected", {
@@ -31,8 +43,22 @@ export function useAppStartup() {
           lastSeenAt: state.lastSeenAt,
         });
       }
+
+      // Covers both the 'data-loss' branch above and a plain empty list (e.g. a FactoryReset
+      // mis-tap, which resets the install marker and so never reaches 'data-loss') — either way,
+      // an empty DB with a safety copy on disk is worth surfacing without a settings hunt.
+      const expenseCount = await db.expenses.count();
+      if (expenseCount === 0) {
+        const manifest = await readManifest();
+        const latest = manifest?.history[0];
+        const prefs = getBackupReminderPreferences();
+        if (latest && latest.expenseCount > 0 && prefs.restoreOfferDeclinedFor !== latest.name) {
+          setRestoreOffer({ name: latest.name, writtenAt: latest.writtenAt, expenseCount: latest.expenseCount });
+          if (!isWipe) setLossDialogOpen(true);
+        }
+      }
     })();
   }, []);
 
-  return { lossCount, setLossCount, lossDialogOpen, setLossDialogOpen };
+  return { lossCount, setLossCount, lossDialogOpen, setLossDialogOpen, restoreOffer, setRestoreOffer };
 }

--- a/src/lib/autoBackup.ts
+++ b/src/lib/autoBackup.ts
@@ -1,0 +1,247 @@
+// Orchestrates both auto-backup tiers: a local OPFS snapshot (Tier 1, always on) and a silent
+// Drive upload (Tier 2, once Drive is linked and a passphrase exists). Runs once per calendar
+// day per tier, on app foreground — see useAppStartup.ts. No background scheduler: PWAs have no
+// dependable background execution, so "first launch of the day" is the trigger.
+import { toast } from "sonner";
+import { db, exportAllData, importData } from "@/db/expenseTrackerDb";
+import {
+  buildBackupEnvelope,
+  encryptData,
+  getBackupReminderPreferences,
+  getStoredPassphrase,
+  markAutoBackup,
+  toDateKey,
+} from "@/lib/backup";
+import { uploadBackupToDrive } from "@/lib/backupTargets";
+import { getDriveCredentials } from "@/db/driveCredentials";
+import { DriveSessionExpiredError, getValidAccessToken } from "@/lib/driveAuth";
+import { capture, captureError } from "@/lib/telemetry";
+import {
+  commitSnapshot,
+  opfsAvailable,
+  readManifest,
+  readSnapshot,
+  SnapshotQuotaError,
+  type SnapshotManifestEntry,
+} from "@/lib/snapshotStore";
+import type { BackupReminderPreferences } from "@/db/userPreferences";
+import type { Category, Expense } from "@/types/expense";
+
+const RETENTION_COUNT = 8;
+const ANOMALY_DROP_RATIO = 0.8;
+const QUOTA_DEGRADE_THRESHOLD = 0.8;
+const DRIVE_BACKUP_FILENAME = "extrack-backup-latest.extrack";
+
+function maxUpdatedAt(expenses: Expense[]): string {
+  return expenses.reduce((max, e) => (e.updatedAt > max ? e.updatedAt : max), "");
+}
+
+/** True if writing `bytes` more (after freeing `freed` from a smaller retention) would push
+ *  usage past `QUOTA_DEGRADE_THRESHOLD` of the origin's quota. `storage.estimate()` is a rough
+ *  browser-reported figure, so this whole check is a heuristic guard, not an exact budget. */
+async function projectedOverQuota(bytes: number, freed = 0): Promise<boolean> {
+  if (!navigator.storage?.estimate) return false;
+  const { usage = 0, quota = 0 } = await navigator.storage.estimate();
+  return usage - freed + bytes > quota * QUOTA_DEGRADE_THRESHOLD;
+}
+
+/** Applies the issue's degrade order when the plain snapshot would push storage past
+ *  `QUOTA_DEGRADE_THRESHOLD`: shrink retention to 1 first (frees quota for this and future
+ *  runs even though it doesn't shrink today's write), then strip attachments — the actual size
+ *  driver — and flag the entry partial. Throws `SnapshotQuotaError` if even that doesn't fit. */
+async function degradeForQuota(
+  expenses: Expense[],
+  categories: Category[],
+  text: string,
+  bytes: number,
+  historyLen: number,
+): Promise<{ text: string; bytes: number; partial: boolean; retain: number }> {
+  if (!(await projectedOverQuota(bytes))) return { text, bytes, partial: false, retain: RETENTION_COUNT };
+
+  const estimate = await navigator.storage.estimate();
+  const freed = historyLen > 0 ? ((estimate.usage ?? 0) / historyLen) * (historyLen - 1) : 0;
+  if (!(await projectedOverQuota(bytes, freed))) return { text, bytes, partial: false, retain: 1 };
+
+  const stripped = expenses.map((expense) => {
+    const { attachment: _attachment, ...rest } = expense;
+    return rest;
+  });
+  const strippedText = buildBackupEnvelope({ expenses: stripped, categories });
+  const strippedBytes = new TextEncoder().encode(strippedText).length;
+  if (await projectedOverQuota(strippedBytes, freed)) throw new SnapshotQuotaError();
+
+  return { text: strippedText, bytes: strippedBytes, partial: true, retain: 1 };
+}
+
+function isUnchangedSinceLastSnapshot(
+  latest: SnapshotManifestEntry | null,
+  expenseCount: number,
+  maxUpdated: string,
+): boolean {
+  return latest !== null && latest.expenseCount === expenseCount && latest.maxUpdatedAt === maxUpdated;
+}
+
+function isCollapsedSinceLastSnapshot(latest: SnapshotManifestEntry | null, expenseCount: number): boolean {
+  return latest !== null && expenseCount < latest.expenseCount * ANOMALY_DROP_RATIO;
+}
+
+async function runTier1(
+  expenses: Expense[],
+  categories: Category[],
+  prefs: BackupReminderPreferences,
+  todayKey: string,
+  force: boolean,
+): Promise<void> {
+  const manifest = await readManifest();
+  const latest: SnapshotManifestEntry | null = manifest?.history[0] ?? null;
+  const currentMax = maxUpdatedAt(expenses);
+
+  if (!force && isUnchangedSinceLastSnapshot(latest, expenses.length, currentMax)) {
+    markAutoBackup({ lastAutoSnapshotAt: todayKey });
+    return;
+  }
+
+  if (!force && latest && isCollapsedSinceLastSnapshot(latest, expenses.length)) {
+    markAutoBackup({
+      autoBackupAnomaly: `Expected ~${latest.expenseCount} expenses, found ${expenses.length}`,
+    });
+    captureError("auto_backup_failed", new Error("expense count collapsed"), {
+      tier: "opfs",
+      stage: "anomaly",
+    });
+    return;
+  }
+
+  const start = Date.now();
+  try {
+    const initialText = buildBackupEnvelope({ expenses, categories });
+    const initialBytes = new TextEncoder().encode(initialText).length;
+    const { text, bytes, partial, retain } = await degradeForQuota(
+      expenses,
+      categories,
+      initialText,
+      initialBytes,
+      manifest?.history.length ?? 0,
+    );
+
+    await commitSnapshot(text, { partial }, retain);
+    markAutoBackup({ lastAutoSnapshotAt: todayKey, autoBackupFailures: 0, autoBackupAnomaly: null });
+    capture("auto_backup_succeeded", {
+      tier: "opfs",
+      expenseCount: expenses.length,
+      byteSize: bytes,
+      durationMs: Date.now() - start,
+    });
+  } catch (err) {
+    markAutoBackup({ autoBackupFailures: prefs.autoBackupFailures + 1 });
+    captureError("auto_backup_failed", err, { tier: "opfs", stage: "write" });
+  }
+}
+
+async function runTier2(
+  expenses: Expense[],
+  categories: Category[],
+  prefs: BackupReminderPreferences,
+  todayKey: string,
+): Promise<void> {
+  const creds = await getDriveCredentials();
+  if (!creds) return;
+  if (!navigator.onLine) return; // offline is not a failure; retried on the next foreground
+
+  const passphrase = await getStoredPassphrase();
+  if (!passphrase) return; // BackupCard derives the actionable row from creds && !passphrase
+
+  const start = Date.now();
+  try {
+    const accessToken = await getValidAccessToken();
+    const encrypted = await encryptData(buildBackupEnvelope({ expenses, categories }));
+    const result = await uploadBackupToDrive(encrypted, DRIVE_BACKUP_FILENAME, accessToken, expenses.length);
+    if (!result) return; // credentials vanished mid-call; treated as a silent no-op
+
+    markAutoBackup({ lastAutoDriveAt: todayKey, autoBackupFailures: 0 });
+    capture("auto_backup_succeeded", {
+      tier: "drive",
+      expenseCount: expenses.length,
+      byteSize: new TextEncoder().encode(encrypted).length,
+      durationMs: Date.now() - start,
+    });
+  } catch (err) {
+    if (err instanceof DriveSessionExpiredError) {
+      // Credentials are already cleared inside driveAuth — structurally no retry.
+      toast.error("Google Drive session expired. Please reconnect.", {
+        action: { label: "Go to Settings", onClick: () => (window.location.href = "/settings/data") },
+      });
+      captureError("auto_backup_failed", err, { tier: "drive", stage: "auth" });
+      return;
+    }
+    markAutoBackup({ autoBackupFailures: prefs.autoBackupFailures + 1 });
+    captureError("auto_backup_failed", err, { tier: "drive", stage: "upload" });
+  }
+}
+
+async function runAutoBackupBody(force: boolean): Promise<void> {
+  const { expenses, categories } = await exportAllData();
+  const prefs = getBackupReminderPreferences();
+  const todayKey = toDateKey(new Date());
+
+  if (expenses.length === 0) {
+    // Nothing to rescue, and a second guard against snapshotting a wipe — a manifest with a
+    // nonzero last count means the DB just went from something to nothing.
+    const manifest = await readManifest();
+    const prevCount = manifest?.history[0]?.expenseCount ?? 0;
+    if (prevCount > 0) {
+      markAutoBackup({ autoBackupAnomaly: `Expected ~${prevCount} expenses, found 0` });
+      captureError("auto_backup_failed", new Error("expense count collapsed to zero"), {
+        tier: "opfs",
+        stage: "anomaly",
+      });
+    }
+    return;
+  }
+
+  if (force || prefs.lastAutoSnapshotAt !== todayKey) {
+    await runTier1(expenses, categories, prefs, todayKey, force);
+  }
+
+  const latestPrefs = getBackupReminderPreferences();
+  if (force || latestPrefs.lastAutoDriveAt !== todayKey) {
+    await runTier2(expenses, categories, latestPrefs, todayKey);
+  }
+}
+
+/** Fired on `window` after every `runAutoBackup` call settles — `AutoBackupStatus` listens for
+ *  this to refresh, since the write happens in a fire-and-forget call from useAppStartup with no
+ *  other signal that state changed. */
+export const AUTO_BACKUP_UPDATED_EVENT = "extrack:auto-backup-updated";
+
+/** Runs both auto-backup tiers, serialized across tabs via the Web Locks API when available.
+ *  `force: true` bypasses the daily gate and the anomaly guard — the manual escape hatch behind
+ *  the "Snapshot now" button after a legitimate large prune blocked the automatic run. */
+export async function runAutoBackup({ force = false }: { force?: boolean } = {}): Promise<void> {
+  if (!opfsAvailable()) return;
+
+  try {
+    if (navigator.locks?.request) {
+      await navigator.locks.request("extrack-auto-backup", () => runAutoBackupBody(force));
+    } else {
+      await runAutoBackupBody(force);
+    }
+  } finally {
+    window.dispatchEvent(new Event(AUTO_BACKUP_UPDATED_EVENT));
+  }
+}
+
+/** Restores a snapshot by name. Refuses one written by a newer schema than the running app, and
+ *  otherwise never touches `validateImportFile` — the 10MB cap that guards user-picked files
+ *  doesn't apply to a snapshot this app wrote itself. */
+export async function restoreSnapshot(name: string): Promise<{ expenseCount: number }> {
+  const snapshot = await readSnapshot(name);
+  if (!snapshot) throw new Error("Safety copy not found");
+  if (snapshot.schemaVersion > db.verno) {
+    throw new Error(
+      "This safety copy was made by a newer version of ExTrack. Update the app to restore it.",
+    );
+  }
+  await importData({ expenses: snapshot.expenses, categories: snapshot.categories });
+  return { expenseCount: snapshot.expenses.length };
+}

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -8,6 +8,7 @@ import {
   isReminderSchedule,
   userPreferences,
 } from "@/db/userPreferences";
+import { db } from "@/db/expenseTrackerDb";
 import type { Expense, Category } from "@/types/expense";
 
 // ---------------------------------------------------------------------------
@@ -88,6 +89,7 @@ export function buildBackupEnvelope(data: { expenses: Expense[]; categories: Cat
     {
       exportDate: new Date().toISOString(),
       version: "1.0",
+      schemaVersion: db.verno,
       expenses: data.expenses,
       categories: data.categories,
     },
@@ -200,7 +202,7 @@ export async function createEncryptedBackupFile(data: {
   return { filename, encrypted };
 }
 
-function toDateKey(value: Date): string {
+export function toDateKey(value: Date): string {
   return format(value, "yyyy-MM-dd");
 }
 
@@ -214,6 +216,11 @@ export function getBackupReminderPreferences(): BackupReminderPreferences {
     lastBackupDate: preferences.lastBackupDate,
     lastBackupMode: preferences.lastBackupMode,
     bannerLastShownDate: preferences.bannerLastShownDate,
+    lastAutoSnapshotAt: preferences.lastAutoSnapshotAt,
+    lastAutoDriveAt: preferences.lastAutoDriveAt,
+    autoBackupFailures: preferences.autoBackupFailures,
+    autoBackupAnomaly: preferences.autoBackupAnomaly,
+    restoreOfferDeclinedFor: preferences.restoreOfferDeclinedFor,
   };
 }
 
@@ -286,6 +293,10 @@ export function markBackupCompleted(
     lastBackupDate: toDateKey(now),
     lastBackupMode: mode,
   });
+}
+
+export function markAutoBackup(patch: Partial<BackupReminderPreferences>): BackupReminderPreferences {
+  return userPreferences.updateBackupReminderPreferences(patch);
 }
 
 export function setBackupReminderSchedule(

--- a/src/lib/snapshotStore.ts
+++ b/src/lib/snapshotStore.ts
@@ -1,0 +1,147 @@
+// Origin Private File System (OPFS) primitives for the automatic local safety-copy snapshot
+// (Tier 1 of the auto-backup feature). A manifest is the "latest" pointer: OPFS has no portable
+// atomic rename, so a snapshot filename alone can never be the commit point. The manifest is
+// written last — a snapshot interrupted mid-write is never referenced by it and is deleted as an
+// orphan the next time this module prunes.
+import type { Category, Expense } from "@/types/expense";
+
+const BACKUP_DIR = "backups";
+export const RETAIN_SNAPSHOTS = 8;
+
+export interface SnapshotManifestEntry {
+  name: string;
+  writtenAt: string; // ISO
+  expenseCount: number;
+  /** Max `Expense.updatedAt` at snapshot time — lets the caller detect "nothing changed" without
+   *  re-reading the snapshot file. ISO-8601 strings compare correctly with `<`/`>`. */
+  maxUpdatedAt: string;
+  /** Attachments were stripped to fit under a tight storage quota. */
+  partial?: boolean;
+}
+
+export interface SnapshotManifest {
+  /** Name of the newest snapshot file in this directory. */
+  latest: string;
+  /** Newest first, length <= RETAIN_SNAPSHOTS. */
+  history: SnapshotManifestEntry[];
+  schemaVersion: number;
+  writtenAt: string;
+}
+
+export interface SnapshotPayload {
+  exportDate: string;
+  version: string;
+  schemaVersion: number;
+  expenses: Expense[];
+  categories: Category[];
+}
+
+export function opfsAvailable(): boolean {
+  return typeof navigator !== "undefined" && typeof navigator.storage?.getDirectory === "function";
+}
+
+async function getBackupsDir(create: boolean): Promise<FileSystemDirectoryHandle | null> {
+  if (!opfsAvailable()) return null;
+  try {
+    const root = await navigator.storage.getDirectory();
+    return await root.getDirectoryHandle(BACKUP_DIR, { create });
+  } catch {
+    return null;
+  }
+}
+
+export async function readManifest(): Promise<SnapshotManifest | null> {
+  const dir = await getBackupsDir(false);
+  if (!dir) return null;
+  try {
+    const file = await (await dir.getFileHandle("manifest.json")).getFile();
+    return JSON.parse(await file.text()) as SnapshotManifest;
+  } catch {
+    return null;
+  }
+}
+
+export async function readSnapshot(name: string): Promise<SnapshotPayload | null> {
+  const dir = await getBackupsDir(false);
+  if (!dir) return null;
+  try {
+    const file = await (await dir.getFileHandle(name)).getFile();
+    return JSON.parse(await file.text()) as SnapshotPayload;
+  } catch {
+    return null;
+  }
+}
+
+export class SnapshotQuotaError extends Error {
+  constructor() {
+    super("Not enough storage quota for a snapshot");
+    this.name = "SnapshotQuotaError";
+  }
+}
+
+/** Deletes every file in `dir` that the new manifest's history no longer references. */
+async function pruneOrphans(dir: FileSystemDirectoryHandle, manifest: SnapshotManifest): Promise<void> {
+  const keep = new Set(manifest.history.map((entry) => entry.name));
+  const names: string[] = [];
+  for await (const name of dir.keys()) {
+    if (name !== "manifest.json" && !keep.has(name)) names.push(name);
+  }
+  await Promise.all(names.map((name) => dir.removeEntry(name).catch(() => {})));
+}
+
+/**
+ * Writes `text` (a JSON-serialized `SnapshotPayload`, plaintext — this never leaves the origin
+ * sandbox) as a new snapshot, verifies it by re-reading and comparing expense counts, then
+ * commits the manifest last and prunes every file the new manifest no longer references.
+ */
+export async function commitSnapshot(
+  text: string,
+  opts: { partial?: boolean } = {},
+  retain: number = RETAIN_SNAPSHOTS,
+): Promise<SnapshotManifest> {
+  const dir = await getBackupsDir(true);
+  if (!dir) throw new Error("OPFS unavailable");
+
+  const parsed = JSON.parse(text) as SnapshotPayload;
+  const name = `snapshot-${Date.now()}.json`;
+
+  try {
+    const handle = await dir.getFileHandle(name, { create: true });
+    const writable = await handle.createWritable();
+    await writable.write(text);
+    await writable.close();
+
+    const reread = JSON.parse(await (await handle.getFile()).text()) as SnapshotPayload;
+    if (!Array.isArray(reread.expenses) || reread.expenses.length !== parsed.expenses.length) {
+      throw new Error("Snapshot verification failed: expense count mismatch after write");
+    }
+  } catch (err) {
+    await dir.removeEntry(name).catch(() => {});
+    if (err instanceof DOMException && err.name === "QuotaExceededError") throw new SnapshotQuotaError();
+    throw err;
+  }
+
+  const previous = await readManifest();
+  const entry: SnapshotManifestEntry = {
+    name,
+    writtenAt: parsed.exportDate,
+    expenseCount: parsed.expenses.length,
+    maxUpdatedAt: parsed.expenses.reduce((max, e) => (e.updatedAt > max ? e.updatedAt : max), ""),
+    ...(opts.partial ? { partial: true as const } : {}),
+  };
+  const history = [entry, ...(previous?.history ?? [])].slice(0, retain);
+  const manifest: SnapshotManifest = {
+    latest: name,
+    history,
+    schemaVersion: parsed.schemaVersion,
+    writtenAt: entry.writtenAt,
+  };
+
+  const manifestHandle = await dir.getFileHandle("manifest.json", { create: true });
+  const manifestWritable = await manifestHandle.createWritable();
+  await manifestWritable.write(JSON.stringify(manifest));
+  await manifestWritable.close();
+
+  await pruneOrphans(dir, manifest);
+  return manifest;
+}

--- a/tests/e2e/auto-backup.spec.ts
+++ b/tests/e2e/auto-backup.spec.ts
@@ -1,0 +1,350 @@
+import type { Page } from "@playwright/test";
+import { test, expect } from "../support/fixtures";
+import { gotoApp, daysAgo } from "../support/app";
+import { seedExpenses, readExpenses } from "../support/db";
+import { thisMonth3 } from "../support/data";
+import { BASE_URL, isDeployed } from "../support/env";
+import { mockDrive } from "../support/mock-drive";
+
+interface SnapshotManifestEntry {
+  name: string;
+  writtenAt: string;
+  expenseCount: number;
+  partial?: boolean;
+}
+
+interface SnapshotManifest {
+  latest: string;
+  history: SnapshotManifestEntry[];
+  schemaVersion: number;
+  writtenAt: string;
+}
+
+// Only this spec reads OPFS, so this helper stays local rather than living in tests/support.
+async function readManifest(page: Page): Promise<SnapshotManifest | null> {
+  return page.evaluate(async () => {
+    try {
+      const root = await navigator.storage.getDirectory();
+      const dir = await root.getDirectoryHandle("backups");
+      const f = await (await dir.getFileHandle("manifest.json")).getFile();
+      return JSON.parse(await f.text());
+    } catch {
+      return null;
+    }
+  });
+}
+
+async function countSnapshotFiles(page: Page): Promise<number> {
+  return page.evaluate(async () => {
+    try {
+      const root = await navigator.storage.getDirectory();
+      const dir = await root.getDirectoryHandle("backups");
+      let count = 0;
+      for await (const name of dir.keys()) {
+        if (name !== "manifest.json") count++;
+      }
+      return count;
+    } catch {
+      return 0;
+    }
+  });
+}
+
+/** Forces every navigation from here on to look like a new day to the auto-backup date-gate —
+ *  the test fixture's own `addInitScript` resets `expense-tracker-backup-reminder` on every
+ *  navigation (see `installHarness`), so a one-off `localStorage.setItem` would be wiped by the
+ *  very reload meant to exercise it. Registering another `addInitScript` after the fixture's
+ *  wins for every subsequent navigation, same recipe as `backup-reminder.spec.ts`. */
+async function forceRolledDay(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    try {
+      const raw = localStorage.getItem("expense-tracker-backup-reminder");
+      const prefs = raw ? JSON.parse(raw) : {};
+      prefs.lastAutoSnapshotAt = "2000-01-01";
+      localStorage.setItem("expense-tracker-backup-reminder", JSON.stringify(prefs));
+    } catch {
+      // init script also runs on about:blank, where storage access can throw
+    }
+  });
+}
+
+/** Clears the `expenses` object store directly, bypassing Dexie — simulates the kind of wipe
+ *  Tier 1 exists to rescue from (corruption, a bad migration, an override import). */
+async function clearExpensesTable(page: Page): Promise<void> {
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        const req = indexedDB.open("ExpenseTrackerDB");
+        req.onerror = () => reject(req.error);
+        req.onsuccess = () => {
+          const db = req.result;
+          const tx = db.transaction("expenses", "readwrite");
+          tx.objectStore("expenses").clear();
+          tx.oncomplete = () => {
+            db.close();
+            resolve();
+          };
+          tx.onerror = () => {
+            db.close();
+            reject(tx.error);
+          };
+        };
+      }),
+  );
+}
+
+test.describe("auto-backup", () => {
+  test("writes an OPFS snapshot and manifest on the first foreground of the day, with no user interaction", async ({
+    page,
+  }) => {
+    await gotoApp(page, "/");
+    // seedExpenses' own reload is the second foreground; the first had 0 expenses and
+    // deliberately wrote nothing (nothing to rescue).
+    await seedExpenses(page, thisMonth3());
+
+    await expect.poll(() => readManifest(page)).not.toBeNull();
+    const manifest = await readManifest(page);
+    expect(manifest?.history[0].expenseCount).toBe(3);
+    expect(manifest?.latest).toBe(manifest?.history[0].name);
+  });
+
+  test("a second foreground on the same day does not write again", async ({ page }) => {
+    await gotoApp(page, "/");
+    await seedExpenses(page, thisMonth3());
+    await expect.poll(() => readManifest(page)).not.toBeNull();
+    const before = await readManifest(page);
+
+    await page.reload();
+    await page.waitForTimeout(500);
+
+    const after = await readManifest(page);
+    expect(after?.writtenAt).toBe(before?.writtenAt);
+    expect(await countSnapshotFiles(page)).toBe(1);
+  });
+
+  test("a rolled day with no data change does not write a new snapshot", async ({ page }) => {
+    await gotoApp(page, "/");
+    await seedExpenses(page, thisMonth3());
+    await expect.poll(() => readManifest(page)).not.toBeNull();
+    const before = await readManifest(page);
+
+    await forceRolledDay(page);
+    await page.reload();
+    await page.waitForTimeout(500);
+
+    const after = await readManifest(page);
+    expect(after?.history.length).toBe(before?.history.length);
+    expect(after?.latest).toBe(before?.latest);
+  });
+
+  test("a rolled day with a new expense writes exactly one snapshot, capped at 8", async ({ page }) => {
+    test.slow();
+    await gotoApp(page, "/");
+    await seedExpenses(page, thisMonth3());
+    await expect.poll(() => readManifest(page)).not.toBeNull();
+
+    for (let i = 0; i < 9; i++) {
+      await forceRolledDay(page);
+      await seedExpenses(page, [
+        { value: 10 + i, categoryName: "Others", description: `Rolled ${i}`, date: daysAgo(0), time: "09:00" },
+      ]);
+      await page.waitForTimeout(400);
+    }
+
+    const manifest = await readManifest(page);
+    expect(manifest?.history.length).toBe(8);
+    expect(await countSnapshotFiles(page)).toBe(8);
+  });
+
+  test("a collapsed expense count does not overwrite the existing snapshot", async ({ page }) => {
+    await gotoApp(page, "/");
+    await seedExpenses(page, thisMonth3());
+    await expect.poll(() => readManifest(page)).not.toBeNull();
+    const before = await readManifest(page);
+
+    await forceRolledDay(page);
+    await clearExpensesTable(page);
+    await page.reload();
+    await page.waitForTimeout(800);
+
+    const after = await readManifest(page);
+    expect(after?.latest).toBe(before?.latest);
+    expect(after?.writtenAt).toBe(before?.writtenAt);
+
+    await page.goto("/settings/data");
+    await expect(page.getByText(/Expected ~3 expenses, found 0/)).toBeVisible();
+  });
+
+  test("a wiped database offers the newest snapshot and restores it in one tap", async ({ page }) => {
+    await gotoApp(page, "/");
+    await seedExpenses(page, thisMonth3());
+    await expect.poll(() => readManifest(page)).not.toBeNull();
+
+    await clearExpensesTable(page);
+    await page.reload();
+
+    const dialog = page.getByRole("alertdialog");
+    await expect(dialog.getByText(/local safety copy.*3.*expenses\. Restore it\?/s)).toBeVisible();
+    await dialog.getByRole("button", { name: "Restore 3 expenses" }).click();
+
+    await expect(page.getByText(/Restored 3 expenses/)).toBeVisible();
+    await page.goto("/transactions");
+    await expect(page.getByText("Groceries")).toBeVisible();
+    await expect(page.getByText("Metro pass")).toBeVisible();
+    await expect(page.getByText("Headphones")).toBeVisible();
+  });
+
+  test("a snapshot larger than 10MB restores", async ({ page }) => {
+    test.slow();
+    const bigAttachment = `data:image/jpeg;base64,${"A".repeat(4_000_000)}`;
+    await gotoApp(page, "/");
+    await seedExpenses(page, [
+      { value: 10, categoryName: "Others", description: "Photo receipt 1", date: daysAgo(0), time: "09:00", attachment: bigAttachment },
+      { value: 20, categoryName: "Others", description: "Photo receipt 2", date: daysAgo(0), time: "10:00", attachment: bigAttachment },
+      { value: 30, categoryName: "Others", description: "Photo receipt 3", date: daysAgo(0), time: "11:00", attachment: bigAttachment },
+    ]);
+
+    await expect.poll(() => readManifest(page), { timeout: 20_000 }).not.toBeNull();
+    const manifest = await readManifest(page);
+    expect(manifest?.history[0].expenseCount).toBe(3);
+    expect(manifest?.history[0].partial).toBeFalsy();
+
+    await clearExpensesTable(page);
+    await page.reload();
+
+    const dialog = page.getByRole("alertdialog");
+    const restoreButton = dialog.getByRole("button", { name: "Restore 3 expenses" });
+    await expect(restoreButton).toBeVisible({ timeout: 20_000 });
+    await restoreButton.click();
+
+    await expect(page.getByText(/Restored 3 expenses/)).toBeVisible({ timeout: 20_000 });
+    await page.goto("/transactions");
+    await expect(page.getByText("Photo receipt 1")).toBeVisible();
+  });
+
+  test("a snapshot from a newer schema version is refused", async ({ page }) => {
+    const FUTURE_SNAPSHOT = "snapshot-9999999999999.json";
+    // Suppress the empty-state restore-offer dialog for this fake snapshot on every navigation —
+    // this test exercises the restore flow via BackupCard's own "Restore from safety copy" list,
+    // not the auto-popped dialog, and a plain localStorage.setItem would be wiped by the very
+    // `goto` navigation below (see forceRolledDay's doc comment for why).
+    await page.addInitScript((name) => {
+      try {
+        const raw = localStorage.getItem("expense-tracker-backup-reminder");
+        const prefs = raw ? JSON.parse(raw) : {};
+        prefs.restoreOfferDeclinedFor = name;
+        localStorage.setItem("expense-tracker-backup-reminder", JSON.stringify(prefs));
+      } catch {
+        // init script also runs on about:blank, where storage access can throw
+      }
+    }, FUTURE_SNAPSHOT);
+
+    await gotoApp(page, "/");
+
+    // Hand-write a manifest + snapshot from schema version 99 — newer than the running app.
+    await page.evaluate(async (name) => {
+      const root = await navigator.storage.getDirectory();
+      const dir = await root.getDirectoryHandle("backups", { create: true });
+      const now = new Date().toISOString();
+
+      const snapshotHandle = await dir.getFileHandle(name, { create: true });
+      const snapshotWritable = await snapshotHandle.createWritable();
+      await snapshotWritable.write(
+        JSON.stringify({
+          exportDate: now,
+          version: "1.0",
+          schemaVersion: 99,
+          expenses: [
+            {
+              id: "future-1",
+              value: 1,
+              category: "c1",
+              tags: [],
+              date: "2026-01-01",
+              time: "09:00",
+              isAdhoc: false,
+              createdAt: now,
+              updatedAt: now,
+            },
+          ],
+          categories: [],
+        }),
+      );
+      await snapshotWritable.close();
+
+      const manifestHandle = await dir.getFileHandle("manifest.json", { create: true });
+      const manifestWritable = await manifestHandle.createWritable();
+      await manifestWritable.write(
+        JSON.stringify({
+          latest: name,
+          history: [{ name, writtenAt: now, expenseCount: 1, maxUpdatedAt: now }],
+          schemaVersion: 99,
+          writtenAt: now,
+        }),
+      );
+      await manifestWritable.close();
+    }, FUTURE_SNAPSHOT);
+
+    await page.goto("/settings/data");
+    await page.getByRole("button", { name: "Restore from safety copy" }).click();
+    await page.getByRole("alertdialog").getByRole("button", { name: "Restore" }).click();
+
+    await expect(page.getByText(/newer version of ExTrack/)).toBeVisible();
+    expect(await readExpenses(page)).toEqual([]);
+  });
+
+  test("Drive linked with a passphrase uploads silently to a fixed name", async ({ page }) => {
+    test.skip(isDeployed, "mocked Drive endpoints are not exercised against deployments");
+    const drive = await mockDrive(page);
+
+    await gotoApp(page, "/settings/data");
+    await seedExpenses(page, thisMonth3());
+    await page.evaluate(() => sessionStorage.setItem("expense-tracker-pkce-verifier", "test-verifier"));
+    await page.goto("/oauth/callback?code=test-code");
+    await expect(page).toHaveURL(`${BASE_URL}/settings/data`);
+
+    await page.getByRole("button", { name: "Set Passphrase" }).click();
+    const setupDialog = page.getByRole("dialog");
+    await setupDialog.getByLabel("Passphrase", { exact: true }).fill("correcthorse123");
+    await setupDialog.getByLabel("Confirm Passphrase").fill("correcthorse123");
+    await setupDialog.getByRole("button", { name: "Set Passphrase" }).click();
+    await expect(page.getByText("Encryption passphrase saved")).toBeVisible();
+
+    await page.reload();
+
+    await expect.poll(() => drive.lastUpload()).toBeTruthy();
+    const uploaded = drive.lastUpload();
+    expect(uploaded).not.toContain("Groceries");
+    expect(JSON.parse(uploaded ?? "{}").format).toBe("extrack-encrypted-backup");
+    expect(drive.lastUploadName()).toBe("extrack-backup-latest.extrack");
+  });
+
+  test("Drive linked without a passphrase skips tier 2 and shows one actionable row", async ({ page }) => {
+    test.skip(isDeployed, "mocked Drive endpoints are not exercised against deployments");
+    await mockDrive(page);
+
+    await gotoApp(page, "/settings/data");
+    await seedExpenses(page, thisMonth3());
+    await page.evaluate(() => sessionStorage.setItem("expense-tracker-pkce-verifier", "test-verifier"));
+    await page.goto("/oauth/callback?code=test-code");
+    await expect(page).toHaveURL(`${BASE_URL}/settings/data`);
+
+    await page.reload();
+    await page.waitForTimeout(500);
+
+    await expect(page.getByText("Drive is linked but no passphrase is set")).toBeVisible();
+    await expect(page.getByText("Backup saved to Google Drive")).toHaveCount(0);
+  });
+
+  test("a browser without OPFS boots normally", async ({ page }) => {
+    await page.addInitScript(() => {
+      const storage = navigator.storage as unknown as { getDirectory?: () => Promise<unknown> };
+      delete storage.getDirectory;
+    });
+    await gotoApp(page, "/");
+    await seedExpenses(page, thisMonth3());
+
+    await page.goto("/settings/data");
+    await expect(page.getByText("Safety copy:", { exact: false })).toHaveCount(0);
+  });
+});

--- a/tests/e2e/data-management.spec.ts
+++ b/tests/e2e/data-management.spec.ts
@@ -96,7 +96,11 @@ test.describe("data-management", () => {
     await expect(page.getByText("No expenses yet. Add your first one!")).toBeVisible();
 
     // Import the encrypted backup back in — passphrase was cleared, so manual entry is required.
+    // A safety-copy snapshot survives the reset (that's the point of Tier 1), so the restore
+    // offer dialog pops up on this empty-list foreground — decline it to continue with the
+    // deliberate manual import this test is exercising.
     await page.goto("/settings/data");
+    await page.getByRole("alertdialog").getByRole("button", { name: "Start fresh" }).click();
     await page.setInputFiles('[data-testid="import-file-input"]', {
       name: "backup.extrack",
       mimeType: "application/octet-stream",
@@ -135,6 +139,7 @@ test.describe("data-management", () => {
     await expect(page.getByText("All data cleared. App reset to default state.")).toBeVisible();
 
     await page.goto("/settings/data");
+    await page.getByRole("alertdialog").getByRole("button", { name: "Start fresh" }).click();
     await page.setInputFiles('[data-testid="import-file-input"]', {
       name: "backup.extrack",
       mimeType: "application/octet-stream",

--- a/tests/support/db.ts
+++ b/tests/support/db.ts
@@ -8,6 +8,7 @@ export type SeedExpense = {
   date: string; // "YYYY-MM-DD"
   time: string; // "HH:mm"
   isAdhoc?: boolean;
+  attachment?: string; // base64 data-URL, for the >10MB-snapshot restore test
 };
 
 type CategoryRow = { id: string; name: string };
@@ -70,6 +71,7 @@ export async function seedExpenses(page: Page, items: SeedExpense[]): Promise<vo
               date: item.date,
               time: item.time,
               isAdhoc: item.isAdhoc ?? false,
+              attachment: item.attachment,
               createdAt: now,
               updatedAt: now,
             });

--- a/tests/support/installed-pwa.ts
+++ b/tests/support/installed-pwa.ts
@@ -124,5 +124,25 @@ export async function runInstalledPwaJourney(handle: InstalledPwaHandle) {
     await handle.context.setOffline(false);
   }
 
+  // 6. Auto-backup Tier 1 runs on every foreground with no user interaction — confirms OPFS
+  // availability isn't gated behind `display-mode: standalone` on any of the three engines this
+  // journey runs on (Brave, Chrome-mobile, WebKit).
+  await page.reload();
+  await expect
+    .poll(() =>
+      page.evaluate(async () => {
+        try {
+          const root = await navigator.storage.getDirectory();
+          const dir = await root.getDirectoryHandle("backups");
+          const file = await (await dir.getFileHandle("manifest.json")).getFile();
+          const manifest: { history: { expenseCount: number }[] } = JSON.parse(await file.text());
+          return manifest.history[0]?.expenseCount ?? 0;
+        } catch {
+          return 0;
+        }
+      }),
+    )
+    .toBeGreaterThanOrEqual(1);
+
   expect(errors, `unexpected console/page errors:\n${errors.join("\n")}`).toEqual([]);
 }

--- a/tests/support/mock-drive.ts
+++ b/tests/support/mock-drive.ts
@@ -5,6 +5,9 @@ export type MockDriveHandle = {
    *  actually sent over the wire, not just what it intended to send. `undefined` until an
    *  upload happens. */
   lastUpload(): string | undefined;
+  /** The `name` field from the most recent upload's `metadata` part — the actual filename Drive
+   *  received, not just what the caller intended. `undefined` until an upload happens. */
+  lastUploadName(): string | undefined;
 };
 
 /** Extracts one named part's body from a `multipart/form-data` request. Google's upload API
@@ -31,6 +34,7 @@ function extractMultipartPart(contentType: string, body: string, partName: strin
  */
 export async function mockDrive(page: Page): Promise<MockDriveHandle> {
   let lastUploadContent: string | undefined;
+  let lastUploadFilename: string | undefined;
 
   await page.route("**oauth2.googleapis.com/token", (route) =>
     route.fulfill({
@@ -70,7 +74,17 @@ export async function mockDrive(page: Page): Promise<MockDriveHandle> {
 
   await page.route("**www.googleapis.com/upload/drive/v3/files**", (route) => {
     const req = route.request();
-    lastUploadContent = extractMultipartPart(req.headers()["content-type"] ?? "", req.postData() ?? "", "file");
+    const contentType = req.headers()["content-type"] ?? "";
+    const body = req.postData() ?? "";
+    lastUploadContent = extractMultipartPart(contentType, body, "file");
+    const metadataPart = extractMultipartPart(contentType, body, "metadata");
+    if (metadataPart) {
+      // Written by buildMetadataBlob in src/lib/driveApi.ts — always { name, mimeType, parents? }.
+      const metadata: { name: string } = JSON.parse(metadataPart);
+      lastUploadFilename = metadata.name;
+    } else {
+      lastUploadFilename = undefined;
+    }
     return route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -85,5 +99,5 @@ export async function mockDrive(page: Page): Promise<MockDriveHandle> {
     route.fulfill({ status: 200, contentType: "text/plain", body: "" }),
   );
 
-  return { lastUpload: () => lastUploadContent };
+  return { lastUpload: () => lastUploadContent, lastUploadName: () => lastUploadFilename };
 }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "ES2024.Promise", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "ES2024.Promise", "DOM", "DOM.Iterable", "DOM.AsyncIterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 

--- a/tsconfig.playwright.json
+++ b/tsconfig.playwright.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2023", "ES2024.Promise", "DOM", "DOM.Iterable"],
+    "lib": ["ES2023", "ES2024.Promise", "DOM", "DOM.Iterable", "DOM.AsyncIterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "types": ["node"],


### PR DESCRIPTION
Closes #60

## What changed

Automatic daily backup, two tiers, plus one-tap restore, per issue #60:

- **Tier 1 (always on):** a plaintext snapshot written to the Origin Private File System
  (`src/lib/snapshotStore.ts`) on first foreground of each calendar day. Retains 8, prunes
  oldest-first, manifest written last so a torn write is never referenced. Refuses to overwrite
  when the expense count collapses (zero, or >20% drop). Degrades under storage pressure
  (fewer retained snapshots, then attachments stripped) instead of throwing.
- **Tier 2 (once Drive linked + passphrase set):** the same daily run silently uploads an
  encrypted `.extrack` to a fixed Drive filename (`extrack-backup-latest.extrack`), replacing
  the previous one. Session-expired clears credentials and prompts reconnect once, never
  retries silently. Offline is not a failure.
- **Restore:** the existing `'data-loss'` detection and `DataLossDialog` now offer a one-tap
  restore from the newest snapshot. The same dialog also appears on any empty expense list with
  a snapshot present (e.g. after a `FactoryReset` mis-tap), not just a detected wipe.
- **UI:** `BackupCard` gets a quiet status row (`AutoBackupStatus`) — last snapshot/Drive time,
  an anomaly row with a manual "Snapshot now" override, a "Drive linked, no passphrase" row, and
  a "Restore from safety copy" list. No success toast. `BackupReminderPrompt` escalates to a
  banner after 3 consecutive automatic-backup failures instead of nagging daily.

## How it works

- `src/lib/snapshotStore.ts` — OPFS primitives: `opfsAvailable`, `readManifest`, `readSnapshot`,
  `commitSnapshot` (write → reread-and-verify → write manifest last → prune orphans).
- `src/lib/autoBackup.ts` — orchestration: `runAutoBackup({force})` (Web Locks–serialized across
  tabs), `restoreSnapshot(name)` (refuses a newer schema version, otherwise calls `importData`
  directly — never touches the 10MB `validateImportFile` cap since that's file-input-only).
- `src/hooks/useAppStartup.ts` — fires `runAutoBackup()` fire-and-forget after
  `initializeDatabase()`, and independently computes a restore offer whenever
  `db.expenses.count() === 0` and a snapshot with expenses exists.
- `src/db/userPreferences.ts` / `src/lib/backup.ts` — additive fields on
  `BackupReminderPreferences` (`lastAutoSnapshotAt`, `lastAutoDriveAt`, `autoBackupFailures`,
  `autoBackupAnomaly`, `restoreOfferDeclinedFor`), a new `markAutoBackup` setter, and
  `schemaVersion: db.verno` added to `buildBackupEnvelope`. `lastBackupDate`/`lastBackupMode`
  semantics untouched, so `backup-reminder.spec.ts` stays green.
- Tier 1 deliberately does **not** call `markBackupCompleted` — a same-origin copy isn't the
  off-device backup the manual-reminder banner nags about.

## Tests added

`tests/e2e/auto-backup.spec.ts` (11 tests, all against `chromium-desktop`):

- `"writes an OPFS snapshot and manifest on the first foreground of the day..."` — asserts
  `manifest.history[0].expenseCount === 3` after seeding, with zero clicks.
- `"a second foreground on the same day does not write again"` — `manifest.writtenAt` and
  snapshot-file count (1) unchanged across a reload.
- `"a rolled day with no data change does not write a new snapshot"` — `history.length`/`latest`
  unchanged after forcing the date-gate to a new day with unchanged data.
- `"a rolled day with a new expense writes exactly one snapshot, capped at 8"` — 9 rolled days
  with a genuinely new expense each time → `history.length === 8`, 8 files on disk.
- `"a collapsed expense count does not overwrite the existing snapshot"` — clearing `expenses`
  out-of-band leaves `manifest.latest`/`writtenAt` unchanged and surfaces
  `"Expected ~3 expenses, found 0"` in `BackupCard`.
- `"a wiped database offers the newest snapshot and restores it in one tap"` — the dialog names
  the date/count; tapping Restore repopulates `/transactions` with all 3 rows.
- `"a snapshot larger than 10MB restores"` — 3 rows with ~4MB attachments each restore
  successfully, proving the internal path never calls `validateImportFile`.
- `"a snapshot from a newer schema version is refused"` — a hand-written `schemaVersion: 99`
  snapshot is rejected with the "newer version" message; `readExpenses` stays empty.
- `"Drive linked with a passphrase uploads silently to a fixed name"` — the captured upload is
  ciphertext (`format: "extrack-encrypted-backup"`) named `extrack-backup-latest.extrack`.
- `"Drive linked without a passphrase skips tier 2..."` — one actionable row, no prompt, no
  success toast.
- `"a browser without OPFS boots normally"` — deleting `navigator.storage.getDirectory` leaves
  the app functional with no "Safety copy:" row and no console error (fixture-enforced).

Also extended `tests/support/installed-pwa.ts`'s shared `runInstalledPwaJourney` with a step 6
polling for a written manifest, covering Brave/Chrome-mobile/WebKit PWA installs in one edit —
not run by this driver's gate (`chromium-desktop` only) but present for the
`*-mobile-pwa` projects.

Two pre-existing `tests/e2e/data-management.spec.ts` tests (`"encrypted round trip..."`,
`"wrong manual passphrase is rejected"`) needed a one-line fix each: they factory-reset a
profile that had just been auto-backed-up, so the new restore-offer dialog now appears on the
resulting empty list and was blocking their manual-import UI. Both now dismiss it via
"Start fresh" before continuing — the assertions they exercise are otherwise unchanged.

`.fallowrc.json` gained `thresholdOverrides` entries for the new module's necessary
multi-branch orchestration (daily gate / skip-unchanged / anomaly guard / quota degrade),
following the file's existing convention for coverage-blind CRAP on intentional branching.

<details>
<summary>Plan (claude-opus-5)</summary>

## Goal

Add an always-on daily local snapshot to OPFS (Tier 1) plus a silent daily Drive upload when Drive is already linked and a passphrase exists (Tier 2), and wire the existing `'data-loss'` detection to a one-tap restore — so the app stops nagging users to do manually what it can do itself, and the wipe it already detects has something to offer back.

## Test first (TDD)

**Path:** `tests/e2e/auto-backup.spec.ts`

**Title:** `test("writes an OPFS snapshot and manifest on the first foreground of the day, with no user interaction", ...)`

Body shape (local helper in the spec, not a new support module — only this spec reads OPFS):

```ts
async function readManifest(page: Page) {
  return page.evaluate(async () => {
    try {
      const root = await navigator.storage.getDirectory();
      const dir = await root.getDirectoryHandle("backups");
      const f = await (await dir.getFileHandle("manifest.json")).getFile();
      return JSON.parse(await f.text());
    } catch { return null; }
  });
}
```

Test: `gotoApp(page, "/")` → `seedExpenses(page, thisMonth3())` (its own reload is the second foreground; the first had 0 expenses and deliberately writes nothing) → `await expect.poll(() => readManifest(page)).not.toBeNull()`.

**The assertion that is RED today:**

```ts
expect(manifest.history[0].expenseCount).toBe(3);
```

Today `navigator.storage.getDirectory()` is never called anywhere in `src/` (grep: zero hits for `getDirectory`, `navigator.locks`, `storage.estimate`), so `readManifest` resolves `null` and the poll times out. It flips to green the moment `runAutoBackup` commits its first manifest.

Rest of the spec (same file, added after the first goes green):

- `"a second foreground on the same day does not write again"` — reload, assert `manifest.writtenAt` unchanged and snapshot file count still 1.
- `"a rolled day with no data change does not write a new snapshot"` — mutate `expense-tracker-backup-reminder` in `page.evaluate` (backdate `lastAutoSnapshotAt`), reload, assert `history` length unchanged.
- `"a rolled day with a new expense writes exactly one snapshot, capped at 8"` — seed 9 rolled days in a loop, assert `history.length === 8`, oldest pruned, snapshot files === 8.
- `"a collapsed expense count does not overwrite the existing snapshot"` — clear the `expenses` object store out-of-band, backdate, reload, assert `latest` and `writtenAt` unchanged and the anomaly row is visible on `/settings/data`.
- `"a wiped database offers the newest snapshot and restores it in one tap"` — clear `expenses` out-of-band, reload, assert the dialog names the date and count, tap Restore, assert `/transactions` shows the rows.
- `"a snapshot larger than 10MB restores"` (`test.slow()`) — 3 seeded rows with ~4MB base64 `attachment` each; proves the internal path never touches `validateImportFile`.
- `"a snapshot from a newer schema version is refused"` — hand-write a manifest with `schemaVersion: 99` into OPFS, attempt restore from `BackupCard`, assert the refusal message and `readExpenses(page)` still empty.
- `"Drive linked with a passphrase uploads silently to a fixed name"` — `mockDrive(page)` + the `/oauth/callback?code=test-code` recipe from `drive-oauth.spec.ts:57-78`, backdate, reload, assert `drive.lastUpload()` is ciphertext and the captured metadata name is `extrack-backup-latest.extrack`.
- `"Drive linked without a passphrase skips tier 2 and shows one actionable row"` — no prompt, no toast, one row in `BackupCard`.
- `"a browser without OPFS boots normally"` — `page.addInitScript(() => { delete (navigator.storage as any).getDirectory; })`, assert app renders and no safety-copy row (the fixture's console-error guard covers "no error surfaces").

Cross-engine coverage rides the existing shared journey rather than a new WebKit spec (`safari-mobile-pwa` only matches `pwa-standalone-safari.spec.ts`): append a step 6 to `runInstalledPwaJourney` (`tests/support/installed-pwa.ts:126`) — `await page.reload()` then poll for a manifest with `expenseCount >= 1`. One edit covers Brave, Chrome-mobile and WebKit at once.

## Changes

1. **`src/db/userPreferences.ts`** — extend `BackupReminderPreferences` with `lastAutoSnapshotAt: string | null`, `lastAutoDriveAt: string | null`, `autoBackupFailures: number`, `autoBackupAnomaly: string | null`, `restoreOfferDeclinedFor: string | null`; add defaults to `DEFAULT_BACKUP_REMINDER_PREFERENCES` and parse them in `getBackupReminderPreferences` alongside the existing `pickString` calls (`:104-126`). Additive only — `reminderSchedule`/`lastBackupDate`/`lastBackupMode` semantics untouched, so `backup-reminder.spec.ts` stays green. Missing/garbage fields fall back to the defaults through the existing try/catch. Reuses the existing store; no parallel timestamp store.

2. **`src/lib/backup.ts`** — mirror the new fields in `getBackupReminderPreferences` (`:207-218`) and add one setter `markAutoBackup(patch: Partial<BackupReminderPreferences>)` next to `markBackupCompleted` (`:281-289`). Also add `schemaVersion: db.verno` to `buildBackupEnvelope` (`:86-97`) — the issue's "version the payload for real"; `buildImportPreview` ignores unknown fields, so existing files still import.

3. **New `src/lib/snapshotStore.ts`** — OPFS primitives; nothing equivalent exists in the repo.
   - `opfsAvailable(): boolean` → `typeof navigator.storage?.getDirectory === "function"`.
   - `readManifest(): Promise<SnapshotManifest | null>` — `null` on missing dir, missing file, or unparseable JSON (a corrupt manifest is treated as no manifest; the next run rewrites it and prunes the orphans).
   - `readSnapshot(name)` — `null` if absent or unparseable.
   - `commitSnapshot(text, entry, retain)` — write `snapshot-<epochMs>.json` with `createWritable()`, **reread and `JSON.parse` it and compare `expenses.length`** (throw on mismatch, delete the bad file), then write `manifest.json`, then delete every file in `backups/` not named in `history`. Manifest write is the commit, so an interrupted snapshot is an unreferenced orphan the next prune removes. `QuotaExceededError` on write → delete the partial file and rethrow a tagged error for the caller to record.

4. **New `src/lib/autoBackup.ts`** — orchestration; nothing equivalent exists.
   - `runAutoBackup({ force = false } = {})`: return if `!opfsAvailable()`; wrap the body in `navigator.locks?.request("extrack-auto-backup", fn)` with a plain `fn()` fallback when `navigator.locks` is absent (one writer per day across tabs); `exportAllData()` (`src/db/expenseTrackerDb.ts:328-335`) once, shared by both tiers; **return before stamping any date if `expenses.length === 0`** — nothing to rescue, and it is a second guard against snapshotting a wipe.
   - Tier 1 runs when `lastAutoSnapshotAt` is not today (`format(…, "yyyy-MM-dd")` comparison, same `toDateKey` idiom as `shouldShowBackupReminderBanner`). Skip-unchanged: compare `expenses.length` + `max(updatedAt)` (computed from the already-exported array — `updatedAt` is unindexed, no schema change) against the latest history entry; equal → touch `lastAutoSnapshotAt`, no write. Anomaly guard: count `=== 0` or `< prev.expenseCount * 0.8` → record `autoBackupAnomaly`, `captureError("auto_backup_failed", …, { tier: "opfs", stage: "anomaly" })`, leave the snapshot and the date alone. Quota: `navigator.storage.estimate()`, and if `usage + bytes > quota * 0.8` degrade in order — retain 1 snapshot, then strip `attachment` (`expenses.map(({attachment, ...e}) => e)`) and mark the entry `partial: true`, then skip and record a failure. Success → `lastAutoSnapshotAt = now`, `autoBackupFailures = 0`, `autoBackupAnomaly = null`, `capture("auto_backup_succeeded", { tier: "opfs", expenseCount, byteSize, durationMs })`. No toast.
   - Tier 2 runs when `getDriveCredentials()` returns creds and `lastAutoDriveAt` is not today. `!navigator.onLine` → return silently, no failure counted. `getStoredPassphrase()` null → return silently (`BackupCard` derives the actionable row from `creds && !passphrase`; no new flag). Otherwise `encryptData(buildBackupEnvelope(data))` (not `createEncryptedBackupFile`, which hardcodes a dated filename) → `uploadBackupToDrive(encrypted, "extrack-backup-latest.extrack", token, count)` from `src/lib/backupTargets.ts:14`, which already replaces by name and already calls `markBackupCompleted("drive")`. `DriveSessionExpiredError` from `getValidAccessToken` → one `toast.error` with the Settings action (credentials are already cleared inside `driveAuth`, so there is structurally no retry); any other error → `autoBackupFailures++` and `captureError("auto_backup_failed", err, { tier: "drive", stage })`.
   - `restoreSnapshot(name)`: read → refuse with `"This safety copy was made by a newer version of ExTrack. Update the app to restore it."` when `snap.schemaVersion > db.verno` (nothing written) → `importData(...)` (`:338-373`, already clears + rebuilds `tagMetadata` + touches the install marker) → success toast noting that currency/theme are not part of a safety copy. Never goes near `validateImportFile`, so the 10MB cap does not apply and needs no edit.

5. **`src/hooks/useAppStartup.ts`** — inside the existing startup effect (already the once-per-open hook), `void runAutoBackup()` after `initializeDatabase()`, and compute the restore offer: when `db.expenses.count() === 0` and `readManifest()` has a latest entry with `expenseCount > 0` and `restoreOfferDeclinedFor !== latest`, open the existing dialog with that snapshot. This single condition covers both the `'data-loss'` branch and the plain-empty-list branch, so no new mount point and no new component. No new hook file and no `App.tsx:74` sibling — `useAppStartup` already owns app-open work.

6. **`src/components/DataLossDialog.tsx` + `src/App.tsx`** — add optional `snapshot: { name; writtenAt; expenseCount } | null`. When present, the description names the date and count and the primary action becomes `Restore <n> expenses` calling `restoreSnapshot`; when absent the component is byte-for-byte today's behaviour, so `data-loss.spec.ts` (which seeds no snapshot) stays green. `onStartFresh` additionally writes `restoreOfferDeclinedFor = latest` so a user who genuinely deleted everything is not re-offered.

7. **New `src/components/more/backup/AutoBackupStatus.tsx`, rendered by `BackupCard`** (`src/components/more/BackupCard.tsx:19`, next to the existing `lastBackupText`) — `Safety copy: today, 09:14 · 1,204 expenses`, `Drive: today, 09:14` when linked, the anomaly row with a `Snapshot now` button calling `runAutoBackup({ force: true })` (the manual escape from a legitimate large prune), the `Drive is linked but no passphrase is set` row, and a `Restore from safety copy` list of `manifest.history` entries with date + count behind an `AlertDialog` confirm. Renders nothing at all when `opfsAvailable()` is false.

8. **`src/components/BackupReminderPrompt.tsx`** — in `getInitialPromptState`, when `autoBackupFailures >= 3` return the failure message instead of the due message, reusing `BackupReminderBanner` and the existing `bannerLastShownDate` once-a-day gate (so it is one banner, not a daily nag). **No suppression logic is needed for the healthy case**: Tier 2 success routes through `markBackupCompleted("drive")`, which sets `lastBackupDate` to today, and `shouldShowBackupReminderBanner` (`src/lib/backup.ts:236-241`) already returns false. Tier 1 deliberately does **not** call `markBackupCompleted` — a same-origin copy is not the off-device backup the banner exists to nag about, and touching it would break the existing spec.

9. **`docs/features/drive-backup.md`** — `:3` status → implemented; `:89-97` and the Phase 4 block `:484-494` → shipped, not future scope; the row-6 cell at `:544`.

## Out

- **File System Access / desktop directory tier** — the issue excludes it; most machinery, fewest users.
- **Worker + `createSyncAccessHandle`** — the issue itself defers it behind profiling; `createWritable` covers Safari 16.4+.
- **Separate passphrase-verifier blob** — `decryptData` already distinguishes the two cases the criterion names: bad envelope → `"Invalid encrypted file"` / `"Not an encrypted backup file"` (`:136,140`), AES-GCM tag failure → `"Wrong passphrase — decryption failed"` (`:170`). A second source of truth adds a failure mode and no information.
- **Weekly dated Drive copy** — Drive keeps revisions of the replaced file for 30 days, and Tier 1 already holds 8 dated local copies; a second remote file doubles quota for overlapping rotation.
- **Merge-vs-override choice on internal restore** — restore is override; the rescue target is a wiped database where the two are identical, and merge remains available through the existing file-import flow. `mergeImportData` is local to `ImportData.tsx` and would have to be exported to share.
- **"No deletion in this session" exemption on the anomaly guard** — the run only fires at foreground, before any deletion in that session can happen, so the flag would always read false. The `Snapshot now` button is the override.
- **`byteSize` / `appVersion` / `categoryCount` manifest fields** — nothing reads them; `byteSize` goes straight to telemetry at write time.
- **Raising `validateImportFile`'s 10MB cap** — the internal restore path never calls it (it is `File`-input-only, `useEncryptedFileImport.ts:11`); the criterion is met by construction and asserted by a test.
- **Serving the newest snapshot from `saveBackupToDevice`** — an optional optimisation; `exportAllData` is already the cheap part of that path.

## Assumptions

- **`db.verno` (currently 2) is the recorded schema version.** Fallback if Dexie reports it inconsistently during an upgrade: a `SNAPSHOT_SCHEMA_VERSION` constant in `snapshotStore.ts` bumped by hand alongside `this.version(n)`.
- **Playwright contexts isolate OPFS**, so no cross-test cleanup is needed. Fallback: a `beforeEach` that removes `backups/` recursively.
- **80% of `estimate()` is the degrade threshold, retention is 8, the anomaly threshold is a 20% drop** — the issue's numbers, taken as given; all three live as named constants at the top of `autoBackup.ts` so tuning is a one-line change.
- **Restore is offered once per snapshot** and declining is remembered in `restoreOfferDeclinedFor`. If that proves too sticky (user declines, then wants it back), the `Restore from safety copy` row in `BackupCard` is the always-available path.
- **The daily gate is per tier**, not one shared run-date, so an offline Tier 2 retries on the next foreground the same day while Tier 1 stays written-once-daily.

Skipped: the third desktop tier, an encryption verifier, and a merge mode on restore — add the verifier when a recovery flow needs to check a passphrase *before* a user depends on it, not before.

</details>

Local gate: `typecheck`, `typecheck:e2e`, `lint`, `playwright --project=chromium-desktop`, `fallow health --min-score 95` — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic daily local safety snapshots, with optional encrypted Google Drive backups.
  * Added backup status, failure warnings, anomaly detection, retention management, and manual “Snapshot now” controls.
  * Added restore offers when the expense list is empty, including historical snapshot selection and schema protection.
  * Added clearer backup guidance when encryption credentials are incomplete.

* **Documentation**
  * Updated Google Drive Backup documentation to reflect the implemented encryption and backup phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->